### PR TITLE
First draft OpenAPI spec and generator code: path, methods, success response, sample schemas, sample auth, sample errors.

### DIFF
--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -9,13 +9,18 @@ use App\Http\Resources\ActivityResource;
 use App\Http\Resources\ActivityCollection;
 use App\Http\Requests\ActivityStoreRequest;
 use App\Http\Requests\ActivityUpdateRequest;
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
 
+#[OpenApi\PathItem]
 class ActivityController extends Controller
 {
     /**
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['activity'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request)
     {
         $this->authorize('view-any', Activity::class);
@@ -33,6 +38,8 @@ class ActivityController extends Controller
      * @param \App\Http\Requests\ActivityStoreRequest $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['activity'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(ActivityStoreRequest $request)
     {
         $this->authorize('create', Activity::class);
@@ -49,6 +56,8 @@ class ActivityController extends Controller
      * @param \App\Models\Activity $activity
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['activity'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function show(Request $request, Activity $activity)
     {
         $this->authorize('view', $activity);
@@ -61,6 +70,8 @@ class ActivityController extends Controller
      * @param \App\Models\Activity $activity
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['activity'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function update(ActivityUpdateRequest $request, Activity $activity)
     {
         $this->authorize('update', $activity);
@@ -77,6 +88,8 @@ class ActivityController extends Controller
      * @param \App\Models\Activity $activity
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['activity'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(Request $request, Activity $activity)
     {
         $this->authorize('delete', $activity);

--- a/app/Http/Controllers/Api/CollectionController.php
+++ b/app/Http/Controllers/Api/CollectionController.php
@@ -9,13 +9,18 @@ use App\Http\Resources\CollectionResource;
 use App\Http\Resources\CollectionCollection;
 use App\Http\Requests\CollectionStoreRequest;
 use App\Http\Requests\CollectionUpdateRequest;
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
 
+#[OpenApi\PathItem]
 class CollectionController extends Controller
 {
     /**
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['collection'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request)
     {
         $this->authorize('view-any', Collection::class);
@@ -33,6 +38,8 @@ class CollectionController extends Controller
      * @param \App\Http\Requests\CollectionStoreRequest $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['collection'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(CollectionStoreRequest $request)
     {
         $this->authorize('create', Collection::class);
@@ -49,6 +56,8 @@ class CollectionController extends Controller
      * @param \App\Models\Collection $collection
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['collection'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function show(Request $request, Collection $collection)
     {
         $this->authorize('view', $collection);
@@ -61,6 +70,8 @@ class CollectionController extends Controller
      * @param \App\Models\Collection $collection
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['collection'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function update(
         CollectionUpdateRequest $request,
         Collection $collection
@@ -79,6 +90,8 @@ class CollectionController extends Controller
      * @param \App\Models\Collection $collection
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['collection'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(Request $request, Collection $collection)
     {
         $this->authorize('delete', $collection);

--- a/app/Http/Controllers/Api/CollectionDocumentsController.php
+++ b/app/Http/Controllers/Api/CollectionDocumentsController.php
@@ -6,7 +6,10 @@ use App\Models\Collection;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\DocumentCollection;
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
 
+#[OpenApi\PathItem]
 class CollectionDocumentsController extends Controller
 {
     /**
@@ -14,6 +17,8 @@ class CollectionDocumentsController extends Controller
      * @param \App\Models\Collection $collection
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['collection-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request, Collection $collection)
     {
         $this->authorize('view', $collection);
@@ -35,6 +40,8 @@ class CollectionDocumentsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['collection-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(
         Request $request,
         Collection $collection,
@@ -53,6 +60,8 @@ class CollectionDocumentsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['collection-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(
         Request $request,
         Collection $collection,

--- a/app/Http/Controllers/Api/CreatorController.php
+++ b/app/Http/Controllers/Api/CreatorController.php
@@ -9,13 +9,18 @@ use App\Http\Resources\CreatorResource;
 use App\Http\Resources\CreatorCollection;
 use App\Http\Requests\CreatorStoreRequest;
 use App\Http\Requests\CreatorUpdateRequest;
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
 
+#[OpenApi\PathItem]
 class CreatorController extends Controller
 {
     /**
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['creator'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request)
     {
         $this->authorize('view-any', Creator::class);
@@ -33,6 +38,8 @@ class CreatorController extends Controller
      * @param \App\Http\Requests\CreatorStoreRequest $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['creator'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(CreatorStoreRequest $request)
     {
         $this->authorize('create', Creator::class);
@@ -49,6 +56,8 @@ class CreatorController extends Controller
      * @param \App\Models\Creator $creator
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['creator'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function show(Request $request, Creator $creator)
     {
         $this->authorize('view', $creator);
@@ -61,6 +70,8 @@ class CreatorController extends Controller
      * @param \App\Models\Creator $creator
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['creator'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function update(CreatorUpdateRequest $request, Creator $creator)
     {
         $this->authorize('update', $creator);
@@ -77,6 +88,8 @@ class CreatorController extends Controller
      * @param \App\Models\Creator $creator
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['creator'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(Request $request, Creator $creator)
     {
         $this->authorize('delete', $creator);

--- a/app/Http/Controllers/Api/CreatorDocumentsController.php
+++ b/app/Http/Controllers/Api/CreatorDocumentsController.php
@@ -6,7 +6,10 @@ use App\Models\Document;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\DocumentCollection;
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
 
+#[OpenApi\PathItem]
 class CreatorDocumentsController extends Controller
 {
     /**
@@ -14,6 +17,8 @@ class CreatorDocumentsController extends Controller
      * @param \App\Models\Creator $creator
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['creator-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request, Creator $creator)
     {
         $this->authorize('view', $creator);
@@ -35,6 +40,8 @@ class CreatorDocumentsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['creator-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(
         Request $request,
         Creator $creator,
@@ -53,6 +60,8 @@ class CreatorDocumentsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['creator-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(
         Request $request,
         Creator $creator,

--- a/app/Http/Controllers/Api/DocumentActivitiesController.php
+++ b/app/Http/Controllers/Api/DocumentActivitiesController.php
@@ -8,6 +8,10 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\ActivityResource;
 use App\Http\Resources\ActivityCollection;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class DocumentActivitiesController extends Controller
 {
     /**
@@ -15,6 +19,8 @@ class DocumentActivitiesController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document-activities'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request, Document $document)
     {
         $this->authorize('view', $document);
@@ -35,6 +41,8 @@ class DocumentActivitiesController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document-activities'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(Request $request, Document $document)
     {
         $this->authorize('create', Activity::class);

--- a/app/Http/Controllers/Api/DocumentCollectionsController.php
+++ b/app/Http/Controllers/Api/DocumentCollectionsController.php
@@ -7,6 +7,10 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\CollectionCollection;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class DocumentCollectionsController extends Controller
 {
     /**
@@ -14,6 +18,8 @@ class DocumentCollectionsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document--collections'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request, Document $document)
     {
         $this->authorize('view', $document);
@@ -35,6 +41,8 @@ class DocumentCollectionsController extends Controller
      * @param \App\Models\Collection $collection
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document--collections'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(
         Request $request,
         Document $document,
@@ -53,6 +61,8 @@ class DocumentCollectionsController extends Controller
      * @param \App\Models\Collection $collection
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document--collections'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(
         Request $request,
         Document $document,

--- a/app/Http/Controllers/Api/DocumentController.php
+++ b/app/Http/Controllers/Api/DocumentController.php
@@ -3,19 +3,28 @@
 namespace App\Http\Controllers\Api;
 
 use App\Models\Document;
+use App\OpenApi\Responses\Document\SuccessfulDocumentsResponse;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\DocumentResource;
 use App\Http\Resources\DocumentCollection;
 use App\Http\Requests\DocumentStoreRequest;
 use App\Http\Requests\DocumentUpdateRequest;
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
 
+#[OpenApi\PathItem]
 class DocumentController extends Controller
 {
     /**
+     * List documents
+     *
+     * Returns a paginated collection of documents, most recent first
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document'])]
+    #[OpenApi\Response(factory: SuccessfulDocumentsResponse::class)]
     public function index(Request $request)
     {
         $this->authorize('view-any', Document::class);
@@ -33,6 +42,7 @@ class DocumentController extends Controller
      * @param \App\Http\Requests\DocumentStoreRequest $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document'])]
     public function store(DocumentStoreRequest $request)
     {
         $this->authorize('create', Document::class);
@@ -48,7 +58,8 @@ class DocumentController extends Controller
      * @param \Illuminate\Http\Request $request
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
-     */
+    */
+    #[OpenApi\Operation(tags: ['document'])]
     public function show(Request $request, Document $document)
     {
         $this->authorize('view', $document);
@@ -60,7 +71,8 @@ class DocumentController extends Controller
      * @param \App\Http\Requests\DocumentUpdateRequest $request
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
-     */
+    */
+    #[OpenApi\Operation(tags: ['document'])]
     public function update(DocumentUpdateRequest $request, Document $document)
     {
         $this->authorize('update', $document);
@@ -76,7 +88,8 @@ class DocumentController extends Controller
      * @param \Illuminate\Http\Request $request
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
-     */
+    */
+    #[OpenApi\Operation(tags: ['document'])]
     public function destroy(Request $request, Document $document)
     {
         $this->authorize('delete', $document);

--- a/app/Http/Controllers/Api/DocumentCreatorsController.php
+++ b/app/Http/Controllers/Api/DocumentCreatorsController.php
@@ -7,6 +7,10 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\CreatorCollection;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class DocumentCreatorsController extends Controller
 {
     /**
@@ -14,6 +18,8 @@ class DocumentCreatorsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document--creators'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request, Document $document)
     {
         $this->authorize('view', $document);
@@ -35,6 +41,8 @@ class DocumentCreatorsController extends Controller
      * @param \App\Models\Creator $creator
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document--creators'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(
         Request $request,
         Document $document,
@@ -53,6 +61,8 @@ class DocumentCreatorsController extends Controller
      * @param \App\Models\Creator $creator
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document--creators'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(
         Request $request,
         Document $document,

--- a/app/Http/Controllers/Api/DocumentEditionsController.php
+++ b/app/Http/Controllers/Api/DocumentEditionsController.php
@@ -8,6 +8,10 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\EditionResource;
 use App\Http\Resources\EditionCollection;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class DocumentEditionsController extends Controller
 {
     /**
@@ -15,6 +19,8 @@ class DocumentEditionsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document--editions'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request, Document $document)
     {
         $this->authorize('view', $document);
@@ -35,6 +41,8 @@ class DocumentEditionsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document--editions'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(Request $request, Document $document)
     {
         $this->authorize('create', Edition::class);

--- a/app/Http/Controllers/Api/DocumentLanguagesController.php
+++ b/app/Http/Controllers/Api/DocumentLanguagesController.php
@@ -7,6 +7,10 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\LanguageCollection;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class DocumentLanguagesController extends Controller
 {
     /**
@@ -14,6 +18,8 @@ class DocumentLanguagesController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document-languages'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request, Document $document)
     {
         $this->authorize('view', $document);
@@ -35,6 +41,8 @@ class DocumentLanguagesController extends Controller
      * @param \App\Models\Language $language
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document-languages'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(
         Request $request,
         Document $document,
@@ -53,6 +61,8 @@ class DocumentLanguagesController extends Controller
      * @param \App\Models\Language $language
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document-languages'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(
         Request $request,
         Document $document,

--- a/app/Http/Controllers/Api/DocumentLocationsController.php
+++ b/app/Http/Controllers/Api/DocumentLocationsController.php
@@ -7,6 +7,10 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\LocationCollection;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class DocumentLocationsController extends Controller
 {
     /**
@@ -14,6 +18,8 @@ class DocumentLocationsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document-locations'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request, Document $document)
     {
         $this->authorize('view', $document);
@@ -35,6 +41,8 @@ class DocumentLocationsController extends Controller
      * @param \App\Models\Location $location
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document-locations'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(
         Request $request,
         Document $document,
@@ -53,6 +61,8 @@ class DocumentLocationsController extends Controller
      * @param \App\Models\Location $location
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document-locations'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(
         Request $request,
         Document $document,

--- a/app/Http/Controllers/Api/DocumentTagsController.php
+++ b/app/Http/Controllers/Api/DocumentTagsController.php
@@ -6,7 +6,10 @@ use App\Models\Document;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\TagCollection;
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
 
+#[OpenApi\PathItem]
 class DocumentTagsController extends Controller
 {
     /**
@@ -14,6 +17,8 @@ class DocumentTagsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document-tags'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request, Document $document)
     {
         $this->authorize('view', $document);
@@ -35,6 +40,8 @@ class DocumentTagsController extends Controller
      * @param \App\Models\Tag $tag
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document-tags'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(Request $request, Document $document, Tag $tag)
     {
         $this->authorize('update', $document);
@@ -50,6 +57,8 @@ class DocumentTagsController extends Controller
      * @param \App\Models\Tag $tag
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['document-tags'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(Request $request, Document $document, Tag $tag)
     {
         $this->authorize('update', $document);

--- a/app/Http/Controllers/Api/EditionController.php
+++ b/app/Http/Controllers/Api/EditionController.php
@@ -10,12 +10,18 @@ use App\Http\Resources\EditionCollection;
 use App\Http\Requests\EditionStoreRequest;
 use App\Http\Requests\EditionUpdateRequest;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class EditionController extends Controller
 {
     /**
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['edition'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request)
     {
         $this->authorize('view-any', Edition::class);
@@ -33,6 +39,8 @@ class EditionController extends Controller
      * @param \App\Http\Requests\EditionStoreRequest $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['edition'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(EditionStoreRequest $request)
     {
         $this->authorize('create', Edition::class);
@@ -49,6 +57,8 @@ class EditionController extends Controller
      * @param \App\Models\Edition $edition
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['edition'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function show(Request $request, Edition $edition)
     {
         $this->authorize('view', $edition);
@@ -61,6 +71,8 @@ class EditionController extends Controller
      * @param \App\Models\Edition $edition
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['edition'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function update(EditionUpdateRequest $request, Edition $edition)
     {
         $this->authorize('update', $edition);
@@ -77,6 +89,8 @@ class EditionController extends Controller
      * @param \App\Models\Edition $edition
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['edition'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(Request $request, Edition $edition)
     {
         $this->authorize('delete', $edition);

--- a/app/Http/Controllers/Api/LanguageController.php
+++ b/app/Http/Controllers/Api/LanguageController.php
@@ -10,12 +10,18 @@ use App\Http\Resources\LanguageCollection;
 use App\Http\Requests\LanguageStoreRequest;
 use App\Http\Requests\LanguageUpdateRequest;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class LanguageController extends Controller
 {
     /**
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['language'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request)
     {
         $this->authorize('view-any', Language::class);
@@ -33,6 +39,8 @@ class LanguageController extends Controller
      * @param \App\Http\Requests\LanguageStoreRequest $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['language'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(LanguageStoreRequest $request)
     {
         $this->authorize('create', Language::class);
@@ -49,6 +57,8 @@ class LanguageController extends Controller
      * @param \App\Models\Language $language
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['language'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function show(Request $request, Language $language)
     {
         $this->authorize('view', $language);
@@ -61,6 +71,8 @@ class LanguageController extends Controller
      * @param \App\Models\Language $language
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['language'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function update(LanguageUpdateRequest $request, Language $language)
     {
         $this->authorize('update', $language);
@@ -77,6 +89,8 @@ class LanguageController extends Controller
      * @param \App\Models\Language $language
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['language'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(Request $request, Language $language)
     {
         $this->authorize('delete', $language);

--- a/app/Http/Controllers/Api/LanguageDocumentsController.php
+++ b/app/Http/Controllers/Api/LanguageDocumentsController.php
@@ -7,6 +7,10 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\DocumentCollection;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class LanguageDocumentsController extends Controller
 {
     /**
@@ -14,6 +18,8 @@ class LanguageDocumentsController extends Controller
      * @param \App\Models\Language $language
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['language-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request, Language $language)
     {
         $this->authorize('view', $language);
@@ -35,6 +41,8 @@ class LanguageDocumentsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['language-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(
         Request $request,
         Language $language,
@@ -53,6 +61,8 @@ class LanguageDocumentsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['language-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(
         Request $request,
         Language $language,

--- a/app/Http/Controllers/Api/LocationController.php
+++ b/app/Http/Controllers/Api/LocationController.php
@@ -10,12 +10,18 @@ use App\Http\Resources\LocationCollection;
 use App\Http\Requests\LocationStoreRequest;
 use App\Http\Requests\LocationUpdateRequest;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class LocationController extends Controller
 {
     /**
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['location'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request)
     {
         $this->authorize('view-any', Location::class);
@@ -33,6 +39,8 @@ class LocationController extends Controller
      * @param \App\Http\Requests\LocationStoreRequest $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['location'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(LocationStoreRequest $request)
     {
         $this->authorize('create', Location::class);
@@ -49,6 +57,8 @@ class LocationController extends Controller
      * @param \App\Models\Location $location
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['location'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function show(Request $request, Location $location)
     {
         $this->authorize('view', $location);
@@ -61,6 +71,8 @@ class LocationController extends Controller
      * @param \App\Models\Location $location
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['location'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function update(LocationUpdateRequest $request, Location $location)
     {
         $this->authorize('update', $location);
@@ -77,6 +89,8 @@ class LocationController extends Controller
      * @param \App\Models\Location $location
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['location'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(Request $request, Location $location)
     {
         $this->authorize('delete', $location);

--- a/app/Http/Controllers/Api/LocationDocumentsController.php
+++ b/app/Http/Controllers/Api/LocationDocumentsController.php
@@ -7,6 +7,10 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\DocumentCollection;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class LocationDocumentsController extends Controller
 {
     /**
@@ -14,6 +18,8 @@ class LocationDocumentsController extends Controller
      * @param \App\Models\Location $location
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['location-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request, Location $location)
     {
         $this->authorize('view', $location);
@@ -35,6 +41,8 @@ class LocationDocumentsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['location-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(
         Request $request,
         Location $location,
@@ -53,6 +61,8 @@ class LocationDocumentsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['location-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(
         Request $request,
         Location $location,

--- a/app/Http/Controllers/Api/TagController.php
+++ b/app/Http/Controllers/Api/TagController.php
@@ -10,12 +10,18 @@ use App\Http\Resources\TagCollection;
 use App\Http\Requests\TagStoreRequest;
 use App\Http\Requests\TagUpdateRequest;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class TagController extends Controller
 {
     /**
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['tag'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request)
     {
         $this->authorize('view-any', Tag::class);
@@ -33,6 +39,8 @@ class TagController extends Controller
      * @param \App\Http\Requests\TagStoreRequest $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['tag'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(TagStoreRequest $request)
     {
         $this->authorize('create', Tag::class);
@@ -49,6 +57,8 @@ class TagController extends Controller
      * @param \App\Models\Tag $tag
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['tag'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function show(Request $request, Tag $tag)
     {
         $this->authorize('view', $tag);
@@ -61,6 +71,8 @@ class TagController extends Controller
      * @param \App\Models\Tag $tag
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['tag'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function update(TagUpdateRequest $request, Tag $tag)
     {
         $this->authorize('update', $tag);
@@ -77,6 +89,8 @@ class TagController extends Controller
      * @param \App\Models\Tag $tag
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['tag'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(Request $request, Tag $tag)
     {
         $this->authorize('delete', $tag);

--- a/app/Http/Controllers/Api/TagDocumentsController.php
+++ b/app/Http/Controllers/Api/TagDocumentsController.php
@@ -7,6 +7,10 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\DocumentCollection;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class TagDocumentsController extends Controller
 {
     /**
@@ -14,6 +18,8 @@ class TagDocumentsController extends Controller
      * @param \App\Models\Tag $tag
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['tag-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request, Tag $tag)
     {
         $this->authorize('view', $tag);
@@ -35,6 +41,8 @@ class TagDocumentsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['tag-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(Request $request, Tag $tag, Document $document)
     {
         $this->authorize('update', $tag);
@@ -50,6 +58,8 @@ class TagDocumentsController extends Controller
      * @param \App\Models\Document $document
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['tag-documents'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(Request $request, Tag $tag, Document $document)
     {
         $this->authorize('update', $tag);

--- a/app/Http/Controllers/Api/UserActivitiesController.php
+++ b/app/Http/Controllers/Api/UserActivitiesController.php
@@ -8,6 +8,10 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\ActivityResource;
 use App\Http\Resources\ActivityCollection;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class UserActivitiesController extends Controller
 {
     /**
@@ -15,6 +19,8 @@ class UserActivitiesController extends Controller
      * @param \App\Models\User $user
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['user-activities'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request, User $user)
     {
         $this->authorize('view', $user);
@@ -35,6 +41,8 @@ class UserActivitiesController extends Controller
      * @param \App\Models\User $user
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['user-activities'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(Request $request, User $user)
     {
         $this->authorize('create', Activity::class);

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -11,12 +11,18 @@ use App\Http\Resources\UserCollection;
 use App\Http\Requests\UserStoreRequest;
 use App\Http\Requests\UserUpdateRequest;
 
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+use App\OpenApi\Responses\SuccessfulResponse;
+
+#[OpenApi\PathItem]
 class UserController extends Controller
 {
     /**
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['user'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function index(Request $request)
     {
         $this->authorize('view-any', User::class);
@@ -34,6 +40,8 @@ class UserController extends Controller
      * @param \App\Http\Requests\UserStoreRequest $request
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['user'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function store(UserStoreRequest $request)
     {
         $this->authorize('create', User::class);
@@ -52,6 +60,8 @@ class UserController extends Controller
      * @param \App\Models\User $user
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['user'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function show(Request $request, User $user)
     {
         $this->authorize('view', $user);
@@ -64,6 +74,8 @@ class UserController extends Controller
      * @param \App\Models\User $user
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['user'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function update(UserUpdateRequest $request, User $user)
     {
         $this->authorize('update', $user);
@@ -86,6 +98,8 @@ class UserController extends Controller
      * @param \App\Models\User $user
      * @return \Illuminate\Http\Response
      */
+    #[OpenApi\Operation(tags: ['user'])]
+    #[OpenApi\Response(factory: SuccessfulResponse::class)]
     public function destroy(Request $request, User $user)
     {
         $this->authorize('delete', $user);

--- a/app/OpenApi/Responses/Document/SuccessfulDocumentsResponse.php
+++ b/app/OpenApi/Responses/Document/SuccessfulDocumentsResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\OpenApi\Responses\Document;
+
+use GoldSpecDigital\ObjectOrientedOAS\Objects\MediaType;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Response;
+use App\OpenApi\Schemas\DocumentSchema;
+use Vyuldashev\LaravelOpenApi\Contracts\Reusable;
+use Vyuldashev\LaravelOpenApi\Factories\ResponseFactory;
+
+class SuccessfulDocumentsResponse extends ResponseFactory
+{
+    public function build(): Response
+    {
+        return Response::ok()
+            ->description('Successful response')
+            ->content(
+            MediaType::json()->schema(DocumentSchema::ref())
+        );
+    }
+}

--- a/app/OpenApi/Responses/SuccessfulResponse.php
+++ b/app/OpenApi/Responses/SuccessfulResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\OpenApi\Responses;
+
+use GoldSpecDigital\ObjectOrientedOAS\Objects\MediaType;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Response;
+use App\OpenApi\Schemas\DocumentSchema;
+use Vyuldashev\LaravelOpenApi\Contracts\Reusable;
+use Vyuldashev\LaravelOpenApi\Factories\ResponseFactory;
+
+class SuccessfulResponse extends ResponseFactory
+{
+    public function build(): Response
+    {
+        return Response::ok()
+            ->description('Successful response')
+            ->content(
+            MediaType::json()
+        );
+    }
+}

--- a/app/OpenApi/Schemas/DocumentSchema.php
+++ b/app/OpenApi/Schemas/DocumentSchema.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+use GoldSpecDigital\ObjectOrientedOAS\Contracts\SchemaContract;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\AllOf;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\AnyOf;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Not;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\OneOf;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
+use Vyuldashev\LaravelOpenApi\Contracts\Reusable;
+use Vyuldashev\LaravelOpenApi\Factories\SchemaFactory;
+
+class DocumentSchema extends SchemaFactory implements Reusable
+{
+    /**
+     * @return AllOf|OneOf|AnyOf|Not|Schema
+     * TODO: complete schema
+     */
+    public function build(): SchemaContract
+    {
+        return Schema::object('Document')
+            ->properties(
+                Schema::string('content_html')
+            );
+    }
+}

--- a/blo_openapi.json
+++ b/blo_openapi.json
@@ -1,0 +1,2127 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Baha'i Library Online",
+        "version": "0.0.0"
+    },
+    "servers": [],
+    "paths": {
+        "\/api\/login": {
+            "post": {
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Login user",
+                "requestBody": {
+                    "description": "Login user",
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/Login"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Token created",
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "token": {
+                                            "type": "string",
+                                            "example": "Bearer token"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/ValidationErrors"
+                    }
+                }
+            }
+        },
+        "\/api\/documents": {
+            "get": {
+                "tags": [
+                    "document"
+                ],
+                "summary": "List documents",
+                "description": "Returns a paginated collection of documents, most recent first",
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/Document"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "document"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/documents\/{document}": {
+            "get": {
+                "tags": [
+                    "document"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "document"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "document"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/documents\/{document}\/editions": {
+            "get": {
+                "tags": [
+                    "document--editions"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "document--editions"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/documents\/{document}\/activities": {
+            "get": {
+                "tags": [
+                    "document-activities"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "document-activities"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/documents\/{document}\/languages": {
+            "get": {
+                "tags": [
+                    "document-languages"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/documents\/{document}\/languages\/{language}": {
+            "post": {
+                "tags": [
+                    "document-languages"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "language",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "document-languages"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "language",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/documents\/{document}\/tags": {
+            "get": {
+                "tags": [
+                    "document-tags"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/documents\/{document}\/tags\/{tag}": {
+            "post": {
+                "tags": [
+                    "document-tags"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tag",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "document-tags"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tag",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/documents\/{document}\/locations": {
+            "get": {
+                "tags": [
+                    "document-locations"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/documents\/{document}\/locations\/{location}": {
+            "post": {
+                "tags": [
+                    "document-locations"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "location",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "document-locations"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "location",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/documents\/{document}\/collections": {
+            "get": {
+                "tags": [
+                    "document--collections"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/documents\/{document}\/collections\/{collection}": {
+            "post": {
+                "tags": [
+                    "document--collections"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "collection",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "document--collections"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "collection",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/documents\/{document}\/creators": {
+            "get": {
+                "tags": [
+                    "document--creators"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/documents\/{document}\/creators\/{creator}": {
+            "post": {
+                "tags": [
+                    "document--creators"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "creator",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "document--creators"
+                ],
+                "parameters": [
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "creator",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/collections": {
+            "get": {
+                "tags": [
+                    "collection"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "collection"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/collections\/{collection}": {
+            "get": {
+                "tags": [
+                    "collection"
+                ],
+                "parameters": [
+                    {
+                        "name": "collection",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "collection"
+                ],
+                "parameters": [
+                    {
+                        "name": "collection",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "collection"
+                ],
+                "parameters": [
+                    {
+                        "name": "collection",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/collections\/{collection}\/documents": {
+            "get": {
+                "tags": [
+                    "collection-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "collection",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/collections\/{collection}\/documents\/{document}": {
+            "post": {
+                "tags": [
+                    "collection-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "collection",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "collection-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "collection",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/tags": {
+            "get": {
+                "tags": [
+                    "tag"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "tag"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/tags\/{tag}": {
+            "get": {
+                "tags": [
+                    "tag"
+                ],
+                "parameters": [
+                    {
+                        "name": "tag",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "tag"
+                ],
+                "parameters": [
+                    {
+                        "name": "tag",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "tag"
+                ],
+                "parameters": [
+                    {
+                        "name": "tag",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/tags\/{tag}\/documents": {
+            "get": {
+                "tags": [
+                    "tag-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "tag",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/tags\/{tag}\/documents\/{document}": {
+            "post": {
+                "tags": [
+                    "tag-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "tag",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "tag-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "tag",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/users": {
+            "get": {
+                "tags": [
+                    "user"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "user"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/users\/{user}": {
+            "get": {
+                "tags": [
+                    "user"
+                ],
+                "parameters": [
+                    {
+                        "name": "user",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "user"
+                ],
+                "parameters": [
+                    {
+                        "name": "user",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "user"
+                ],
+                "parameters": [
+                    {
+                        "name": "user",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/users\/{user}\/activities": {
+            "get": {
+                "tags": [
+                    "user-activities"
+                ],
+                "parameters": [
+                    {
+                        "name": "user",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "user-activities"
+                ],
+                "parameters": [
+                    {
+                        "name": "user",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/languages": {
+            "get": {
+                "tags": [
+                    "language"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "language"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/languages\/{language}": {
+            "get": {
+                "tags": [
+                    "language"
+                ],
+                "parameters": [
+                    {
+                        "name": "language",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "language"
+                ],
+                "parameters": [
+                    {
+                        "name": "language",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "language"
+                ],
+                "parameters": [
+                    {
+                        "name": "language",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/languages\/{language}\/documents": {
+            "get": {
+                "tags": [
+                    "language-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "language",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/languages\/{language}\/documents\/{document}": {
+            "post": {
+                "tags": [
+                    "language-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "language",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "language-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "language",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/locations": {
+            "get": {
+                "tags": [
+                    "location"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "location"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/locations\/{location}": {
+            "get": {
+                "tags": [
+                    "location"
+                ],
+                "parameters": [
+                    {
+                        "name": "location",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "location"
+                ],
+                "parameters": [
+                    {
+                        "name": "location",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "location"
+                ],
+                "parameters": [
+                    {
+                        "name": "location",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/locations\/{location}\/documents": {
+            "get": {
+                "tags": [
+                    "location-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "location",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/locations\/{location}\/documents\/{document}": {
+            "post": {
+                "tags": [
+                    "location-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "location",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "location-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "location",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/creators": {
+            "get": {
+                "tags": [
+                    "creator"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "creator"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/creators\/{creator}": {
+            "get": {
+                "tags": [
+                    "creator"
+                ],
+                "parameters": [
+                    {
+                        "name": "creator",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "creator"
+                ],
+                "parameters": [
+                    {
+                        "name": "creator",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "creator"
+                ],
+                "parameters": [
+                    {
+                        "name": "creator",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/creators\/{creator}\/documents": {
+            "get": {
+                "tags": [
+                    "creator-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "creator",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/creators\/{creator}\/documents\/{document}": {
+            "post": {
+                "tags": [
+                    "creator-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "creator",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "creator-documents"
+                ],
+                "parameters": [
+                    {
+                        "name": "creator",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "document",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/editions": {
+            "get": {
+                "tags": [
+                    "edition"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "edition"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/editions\/{edition}": {
+            "get": {
+                "tags": [
+                    "edition"
+                ],
+                "parameters": [
+                    {
+                        "name": "edition",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "edition"
+                ],
+                "parameters": [
+                    {
+                        "name": "edition",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "edition"
+                ],
+                "parameters": [
+                    {
+                        "name": "edition",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/activities": {
+            "get": {
+                "tags": [
+                    "activity"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "activity"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/activities\/{activity}": {
+            "get": {
+                "tags": [
+                    "activity"
+                ],
+                "parameters": [
+                    {
+                        "name": "activity",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "activity"
+                ],
+                "parameters": [
+                    {
+                        "name": "activity",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "activity"
+                ],
+                "parameters": [
+                    {
+                        "name": "activity",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application\/json": {}
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Document": {
+                "type": "object",
+                "properties": {
+                    "content_html": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Login": {
+                "type": "object",
+                "properties": {
+                    "email": {
+                        "type": "string"
+                    },
+                    "password": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "responses": {
+            "ValidationErrors": {
+                "description": "Validation errors",
+                "content": {
+                    "application\/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "type": "string",
+                                    "example": "The given data was invalid."
+                                },
+                                "errors": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "example": {
+                                        "field": [
+                                            "first error",
+                                            "second error",
+                                            "X error"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "auth",
+            "description": "Application auth related endpoints"
+        }
+    ]
+}

--- a/config/openapi.php
+++ b/config/openapi.php
@@ -9,14 +9,14 @@ return [
         'default' => [
 
             'info' => [
-                'title' => config('app.name'),
+                'title' => "Baha'i Library Online",
                 'description' => null,
-                'version' => '1.0.0',
+                'version' => '0.0.0',
             ],
 
             'servers' => [
                 [
-                    'url' => env('APP_URL'),
+                    'url' => env('https://0.0.0.0'),
                 ],
             ],
 


### PR DESCRIPTION
Added laravel-openapi to generate basic open api skeleton for entire app. Missing a lot of spec detail (specially security schemas and full responses, but covers all endpoints.

Corrected the auto-generated spec to produce `blo_openapi.json` which is valid and has been added to postman along with sample collections.